### PR TITLE
feat: core artboard selection functionality complete

### DIFF
--- a/code.js
+++ b/code.js
@@ -1,0 +1,31 @@
+figma.showUI(__html__, { width: 300, height: 150 });
+
+figma.ui.onmessage = msg => {
+  if (msg.type === 'find-similar-artboards') {
+    const selection = figma.currentPage.selection;
+    
+    if (selection.length === 0) {
+      return;
+    }
+    
+    const referenceFrame = selection[0];
+    
+    if (referenceFrame.type !== 'FRAME') {
+      return;
+    }
+    
+    const referenceWidth = referenceFrame.width;
+    const referenceHeight = referenceFrame.height;
+    
+    const topLevelFrames = figma.currentPage.children.filter(node => 
+      node.type === 'FRAME' && 
+      node.width === referenceWidth && 
+      node.height === referenceHeight
+    );
+    
+    figma.currentPage.selection = topLevelFrames;
+    figma.viewport.scrollAndZoomIntoView(topLevelFrames);
+    
+    figma.closePlugin();
+  }
+};

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "openboard",
+  "id": "artboard-selector",
+  "api": "0.1.0",
+  "main": "code.js",
+  "ui": "ui.html",
+  "capabilities": [],
+  "enableProposedApi": false,
+  "editorType": [
+    "figma"
+  ],
+  "networkAccess": {
+    "allowedDomains": [
+      "none"
+    ]
+  }
+}

--- a/ui.html
+++ b/ui.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      margin: 0;
+      padding: 20px;
+      background: white;
+    }
+    
+    .container {
+      display: flex;
+      flex-direction: column;
+      gap: 15px;
+      align-items: center;
+    }
+    
+    .instruction {
+      font-size: 14px;
+      color: #333;
+      text-align: center;
+      line-height: 1.4;
+    }
+    
+    .button {
+      background: #18A0FB;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      padding: 8px 16px;
+      font-size: 14px;
+      cursor: pointer;
+      font-weight: 500;
+    }
+    
+    .button:hover {
+      background: #0F8BD9;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="instruction">
+      Select a frame to use as artboard reference, then click the button below.
+    </div>
+    <button class="button" id="find-button">Find Similar Artboards</button>
+  </div>
+
+  <script>
+    document.getElementById('find-button').onclick = () => {
+      parent.postMessage({ pluginMessage: { type: 'find-similar-artboards' } }, '*');
+    };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
  -  selects all frames with identical dimensions to a user-selected reference frame
  -  works on current page only, targeting top-level frames exclusively
  -  Simple UX: user selects reference frame → clicks button → all matching artboards get selected